### PR TITLE
replace deprecated function async_get_registry

### DIFF
--- a/st_edge_connector/__init__.py
+++ b/st_edge_connector/__init__.py
@@ -205,7 +205,7 @@ async def async_setup_entry(hass, config_entry):
     if conf is None:
         conf = config_entry.data
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = hass.helpers.device_registry.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(CONNECTION_UPNP, CONNECTIONS_VALUE)},

--- a/st_edge_connector/config_flow.py
+++ b/st_edge_connector/config_flow.py
@@ -133,13 +133,13 @@ class DeviceOptionsFlowHandler(config_entries.OptionsFlow):
             selected = user_input.get(CONF_DEVICE, "").split("[")
             title = selected[1][0:len(selected[1])]
 
-            device_registry = await self.hass.helpers.device_registry.async_get_registry()
+            device_registry = self.hass.helpers.device_registry.async_get(self.hass)
             device = device_registry.async_get_device(
                 connections={(CONNECTION_UPNP, CONNECTIONS_VALUE)},
                 identifiers={(DOMAIN, IDENTIFIERS_VALUE)},
             )
 
-            entity_registry = await self.hass.helpers.entity_registry.async_get_registry()
+            entity_registry = self.hass.helpers.entity_registry.async_get(self.hass)
             entity = entity_registry.async_get_or_create(
                 DOMAIN,
                 "edge-driver",


### PR DESCRIPTION
deprecated 된 async_get_registry 함수가 사용되어 HA 2023.5.1 버전부터 에러가 발생합니다.
async_get 함수를 사용하도록 수정하였습니다.
2023.5.1 버전에서 문제없이 작동됨을 확인하였습니다.